### PR TITLE
Add ast-grep to brew setup and update settings.json defaults

### DIFF
--- a/bin/osx.sh
+++ b/bin/osx.sh
@@ -89,6 +89,7 @@ function brew_setup() {
     # brew install zsh-autosuggestions # Fish-like autosuggestions for zsh
 
     brew install agent-browser # Browser automation CLI for AI agents
+    brew install ast-grep # AST-based code search tool
     brew install aws-cdk # Cloud Development Kit for AWS
     brew install awscli # Official Amazon AWS command-line interface
     brew install bash # Bourne-Again SHell, a UNIX command interpreter

--- a/home/.pi/agent/settings.json
+++ b/home/.pi/agent/settings.json
@@ -12,8 +12,8 @@
 		"npm:pi-slop-review"
 	],
 	"extensions": ["~/dotfiles/home/.pi/agent/extensions"],
-	"defaultProvider": "github-copilot",
-	"defaultModel": "gpt-5.4",
+	"defaultProvider": "synthetic",
+	"defaultModel": "hf:moonshotai/Kimi-K2.6",
 	"defaultThinkingLevel": "high",
 	"treeFilterMode": "no-tools",
 	"theme": "dark",


### PR DESCRIPTION
This pull request updates the default AI provider and model used in the `home/.pi/agent/settings.json` configuration file. The new defaults switch from GitHub Copilot to a synthetic provider and from the GPT-5.4 model to the `hf:moonshotai/Kimi-K2.6` model.

Configuration updates:

* Changed `defaultProvider` from `"github-copilot"` to `"synthetic"` in `settings.json`.
* Changed `defaultModel` from `"gpt-5.4"` to `"hf:moonshotai/Kimi-K2.6"` in `settings.json`.