### PR TITLE
Disable quick terminal autohide and add Guardrails extension

### DIFF
--- a/docs/agents/guardrails/CONTEXT.md
+++ b/docs/agents/guardrails/CONTEXT.md
@@ -1,0 +1,42 @@
+# Guardrails Extension
+
+Domain language for the pi guardrails extension — an agent safety layer that enforces file access policies and command confirmation gates via `tool_call` event hooks.
+
+## Language
+
+**Guardrail**: The umbrella term for all protection mechanisms (policies, permission gates, path access rules).
+_Avoid_: Safety rule, restriction, filter
+
+**Policy**: A rule that restricts file or path access. Has a `protection` level: `noAccess` (fully blocked) or `readOnly` (writes blocked, reads allowed).
+_Avoid_: Access rule, file rule, block rule
+
+**PermissionGate**: A rule that triggers a user confirmation dialog before executing a dangerous bash command (e.g. `rm`, `sudo`, `git force-push`).
+_Avoid_: Command filter, safety check, prompt
+
+**PathAccess**: A whitelist-mode feature. When enabled, any file operation on a path not in `allowedPaths` requires user confirmation. When disabled, the entire section is inert.
+
+**allowedPaths**: A global whitelist that overrides ALL policies. If a path matches, it bypasses every rule.
+
+**allowedPatterns**: Per-rule whitelists. Patterns within a specific policy that are exempted from that policy's restrictions (e.g. `.env.example` exempted from the `secret-files` policy).
+
+**onlyIfExists**: A policy flag meaning the rule only triggers if the target path already exists on disk. Allows the agent to create new files matching secret patterns.
+
+## Relationships
+
+- A **Guardrail** config contains **Policies**, **PermissionGates**, and optionally **PathAccess** rules
+- A **Policy** applies to one or more file **Tools** (read, write, edit, find, grep, bash)
+- A **PermissionGate** applies only to the bash tool
+- **allowedPaths** overrides all **Policies** and **PermissionGates**
+- **allowedPatterns** are scoped to individual **Policies**
+
+## Example dialogue
+
+> **Dev:** "If the agent tries to `cat .env`, what happens?"
+> **Domain expert:** "The `secret-files` **Policy** blocks the read with an explicit denial message. The agent knows the file exists but can't access it."
+>
+> **Dev:** "What about `rm -rf node_modules`?"
+> **Domain expert:** "Two things: the **PermissionGate** catches `rm` and shows a confirmation dialog. Separately, `node_modules` is a `readOnly` **Policy** path, so writes are blocked too."
+
+## Flagged ambiguities
+
+- None yet.

--- a/home/.agents/skills/personal/cmux/SKILL.md
+++ b/home/.agents/skills/personal/cmux/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: cmux
+description: End-user control of cmux topology and routing (windows, workspaces, panes/surfaces, focus, moves, reorder, identify, trigger flash). Use when automation needs deterministic placement and navigation in a multi-pane cmux layout.
+---
+
+# cmux Core Control
+
+Use this skill to control non-browser cmux topology and routing.
+
+## Core Concepts
+
+- Window: top-level macOS cmux window.
+- Workspace: tab-like group within a window.
+- Pane: split container in a workspace.
+- Surface: a tab within a pane (terminal or browser panel).
+
+## Fast Start
+
+```bash
+# identify current caller context
+cmux identify --json
+
+# list topology
+cmux list-windows
+cmux list-workspaces
+cmux list-panes
+cmux list-pane-surfaces --pane pane:1
+
+# create/focus/move
+cmux new-workspace
+cmux new-split right --panel pane:1
+cmux move-surface --surface surface:7 --pane pane:2 --focus true
+cmux split-off --surface surface:7 right
+cmux reorder-surface --surface surface:7 --before surface:3
+
+# attention cue
+cmux trigger-flash --surface surface:7
+```
+
+## Settings and Docs
+
+Use `cmux docs settings` before changing cmux-owned settings. It prints the docs URL, schema URL, raw GitHub resources, cmux.json paths, and reload command.
+
+```bash
+cmux docs settings
+cmux settings path
+```
+
+cmux-owned settings live in `~/.config/cmux/cmux.json`. Legacy `~/.config/cmux/settings.json` and `~/Library/Application Support/com.cmuxterm.app/settings.json` files are read only as fallback for missing keys. Before editing, copy any existing `cmux.json` file to a timestamped `.bak` next to it so the user can revert. Edit the user file, then reload:
+
+```bash
+cmux reload-config
+```
+
+`cmux reload-config` reloads BOTH `cmux.json` and Ghostty config (`~/.config/ghostty/config`) and refreshes terminals in place. No app restart needed.
+
+Use cmux settings for app behavior, sidebar, notifications, browser behavior, automation, workspace colors, and cmux-owned shortcuts. Terminal rendering settings such as font, cursor style, theme, scrollback, background transparency (`background-opacity`), and blur (`background-blur`) belong in Ghostty config at `~/.config/ghostty/config`.
+
+Open the UI when useful:
+
+```bash
+cmux settings
+cmux settings cmux-json
+cmux settings shortcuts
+```
+
+## Handle Model
+
+- Default output uses short refs: `window:N`, `workspace:N`, `pane:N`, `surface:N`.
+- UUIDs are still accepted as inputs.
+- Request UUID output only when needed: `--id-format uuids|both`.
+
+## Deep-Dive References
+
+| Reference | When to Use |
+|-----------|-------------|
+| [references/handles-and-identify.md](references/handles-and-identify.md) | Handle syntax, self-identify, caller targeting |
+| [references/windows-workspaces.md](references/windows-workspaces.md) | Window/workspace lifecycle and reorder/move |
+| [references/panes-surfaces.md](references/panes-surfaces.md) | Splits, surfaces, move/reorder, focus routing |
+| [references/trigger-flash-and-health.md](references/trigger-flash-and-health.md) | Flash cue and surface health checks |
+| [../cmux-workspace/SKILL.md](../cmux-workspace/SKILL.md) | Current caller workspace rules and non-disruptive automation |
+| [../cmux-settings/SKILL.md](../cmux-settings/SKILL.md) | Safe cmux.json settings edits and validation |
+| [../cmux-browser/SKILL.md](../cmux-browser/SKILL.md) | Browser automation on surface-backed webviews |
+| [../cmux-markdown/SKILL.md](../cmux-markdown/SKILL.md) | Markdown viewer panel with live file watching |

--- a/home/.agents/skills/personal/cmux/agents/openai.yaml
+++ b/home/.agents/skills/personal/cmux/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cmux Core"
+  short_description: "Control windows/workspaces/panes/surfaces and routing with cmux CLI."
+  default_prompt: "Use this skill to inspect and manipulate cmux topology: identify context, target handles, create/focus/move/reorder windows/workspaces/panes/surfaces, and use trigger-flash for visual confirmation."

--- a/home/.agents/skills/personal/cmux/references/handles-and-identify.md
+++ b/home/.agents/skills/personal/cmux/references/handles-and-identify.md
@@ -1,0 +1,35 @@
+# Handles and Identify
+
+Use `identify` and short handles for deterministic automation targeting.
+
+## Handle Inputs
+
+Most v2-backed commands accept:
+- UUID
+- short ref (`window:N`, `workspace:N`, `pane:N`, `surface:N`)
+- index (where legacy/index-based commands still allow it)
+
+## Self Identify
+
+```bash
+cmux identify --json
+```
+
+Returns current focused topology plus optional caller resolution.
+
+## Caller Override
+
+```bash
+cmux identify --workspace workspace:2
+cmux identify --workspace workspace:2 --surface surface:8
+```
+
+Useful for agents that need to route relative actions from a known caller anchor.
+
+## Output Shaping
+
+```bash
+cmux --json identify                 # refs-first output
+cmux --json --id-format both identify
+cmux --json --id-format uuids identify
+```

--- a/home/.agents/skills/personal/cmux/references/panes-surfaces.md
+++ b/home/.agents/skills/personal/cmux/references/panes-surfaces.md
@@ -1,0 +1,37 @@
+# Panes and Surfaces
+
+Split layout, surface creation, focus, move, and reorder.
+
+## Inspect
+
+```bash
+cmux list-panes
+cmux list-pane-surfaces --pane pane:1
+```
+
+## Create Splits/Surfaces
+
+```bash
+cmux new-split right --panel pane:1
+cmux new-surface --type terminal --pane pane:1
+cmux new-surface --type browser --pane pane:1 --url https://example.com
+```
+
+## Focus and Close
+
+```bash
+cmux focus-pane --pane pane:2
+cmux focus-panel --panel surface:7
+cmux close-surface --surface surface:7
+```
+
+## Move/Reorder Surfaces
+
+```bash
+cmux move-surface --surface surface:7 --pane pane:2 --focus true
+cmux move-surface --surface surface:7 --workspace workspace:2 --window window:1 --after surface:4
+cmux split-off --surface surface:7 right
+cmux reorder-surface --surface surface:7 --before surface:3
+```
+
+Surface identity is stable across move/reorder/split-off operations. Layout commands are focus-neutral by default; pass `--focus true` only when you want the moved or created surface selected.

--- a/home/.agents/skills/personal/cmux/references/trigger-flash-and-health.md
+++ b/home/.agents/skills/personal/cmux/references/trigger-flash-and-health.md
@@ -1,0 +1,23 @@
+# Trigger Flash and Surface Health
+
+Operational checks useful in automation loops.
+
+## Trigger Flash
+
+Flash a surface or workspace to provide visual confirmation in UI:
+
+```bash
+cmux trigger-flash --surface surface:7
+cmux trigger-flash --workspace workspace:2
+```
+
+## Surface Health
+
+Use health output to detect hidden/detached/non-windowed surfaces:
+
+```bash
+cmux surface-health
+cmux surface-health --workspace workspace:2
+```
+
+Use this before routing focused input if UI state may be stale.

--- a/home/.agents/skills/personal/cmux/references/windows-workspaces.md
+++ b/home/.agents/skills/personal/cmux/references/windows-workspaces.md
@@ -1,0 +1,31 @@
+# Windows and Workspaces
+
+Window/workspace lifecycle and ordering operations.
+
+## Inspect
+
+```bash
+cmux list-windows
+cmux current-window
+cmux list-workspaces
+cmux current-workspace
+```
+
+## Create/Focus/Close
+
+```bash
+cmux new-window
+cmux focus-window --window window:2
+cmux close-window --window window:2
+
+cmux new-workspace
+cmux select-workspace --workspace workspace:4
+cmux close-workspace --workspace workspace:4
+```
+
+## Reorder and Move
+
+```bash
+cmux reorder-workspace --workspace workspace:4 --before workspace:2
+cmux move-workspace-to-window --workspace workspace:4 --window window:1
+```

--- a/home/.config/ghostty/config
+++ b/home/.config/ghostty/config
@@ -114,7 +114,7 @@ mouse-hide-while-typing = true
 # Toggle with º key (global hotkey works even when Ghostty isn't focused)
 keybind = global:º=toggle_quick_terminal
 quick-terminal-position = top
-quick-terminal-autohide = true
+quick-terminal-autohide = false
 quick-terminal-size = 100%,100%
 quick-terminal-keyboard-interactivity = exclusive
 

--- a/home/.config/vscode/settings.json
+++ b/home/.config/vscode/settings.json
@@ -102,17 +102,17 @@
 	"aws.telemetry": false,
 	"breadcrumbs.enabled": false,
 	"chat.instructionsFilesLocations": {
-		".github/instructions": true,
-		".claude/rules": true,
-		"~/.copilot/instructions": true,
-		"~/.claude/rules": true,
-		"/var/folders/jq/xkyvscnx7g5c9tn3dbmf09240000gq/T/postman-collections-post-response.instructions.md": true,
-		"/var/folders/jq/xkyvscnx7g5c9tn3dbmf09240000gq/T/postman-collections-pre-request.instructions.md": true,
-		"/var/folders/jq/xkyvscnx7g5c9tn3dbmf09240000gq/T/postman-folder-post-response.instructions.md": true,
-		"/var/folders/jq/xkyvscnx7g5c9tn3dbmf09240000gq/T/postman-folder-pre-request.instructions.md": true,
-		"/var/folders/jq/xkyvscnx7g5c9tn3dbmf09240000gq/T/postman-http-request-post-response.instructions.md": true,
-		"/var/folders/jq/xkyvscnx7g5c9tn3dbmf09240000gq/T/postman-http-request-pre-request.instructions.md": true
-	},
+        ".github/instructions": true,
+        ".claude/rules": true,
+        "~/.copilot/instructions": true,
+        "~/.claude/rules": true,
+        "/var/folders/jq/xkyvscnx7g5c9tn3dbmf09240000gq/T/postman-collections-post-response.instructions.md": true,
+        "/var/folders/jq/xkyvscnx7g5c9tn3dbmf09240000gq/T/postman-collections-pre-request.instructions.md": true,
+        "/var/folders/jq/xkyvscnx7g5c9tn3dbmf09240000gq/T/postman-folder-post-response.instructions.md": true,
+        "/var/folders/jq/xkyvscnx7g5c9tn3dbmf09240000gq/T/postman-folder-pre-request.instructions.md": true,
+        "/var/folders/jq/xkyvscnx7g5c9tn3dbmf09240000gq/T/postman-http-request-post-response.instructions.md": true,
+        "/var/folders/jq/xkyvscnx7g5c9tn3dbmf09240000gq/T/postman-http-request-pre-request.instructions.md": true
+    },
 	"chat.mcp.gallery.enabled": true,
 	"chat.tools.terminal.autoApprove": {
 		"bun": true,

--- a/home/.pi/agent/extensions/guardrails/config.ts
+++ b/home/.pi/agent/extensions/guardrails/config.ts
@@ -1,0 +1,83 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+export interface PolicyRule {
+	id: string;
+	description: string;
+	patterns: Array<{ pattern: string }>;
+	allowedPatterns?: Array<{ pattern: string }>;
+	protection: "noAccess" | "readOnly";
+	onlyIfExists?: boolean;
+}
+
+export interface PermissionGatePattern {
+	pattern: string;
+	description: string;
+}
+
+export interface GuardrailsConfig {
+	enabled: boolean;
+	features: {
+		policies: boolean;
+		permissionGate: boolean;
+		pathAccess: boolean;
+	};
+	pathAccess: {
+		mode: string;
+		allowedPaths: Array<{ pattern: string }>;
+	};
+	policies: {
+		rules: PolicyRule[];
+	};
+	permissionGate: {
+		patterns: PermissionGatePattern[];
+		customPatterns: PermissionGatePattern[];
+		requireConfirmation: boolean;
+		allowedPatterns: PermissionGatePattern[];
+		autoDenyPatterns: PermissionGatePattern[];
+	};
+}
+
+function defaultConfigPath(): string {
+	return path.join(os.homedir(), ".pi", "agent", "guardrails.json");
+}
+
+export function loadConfig(opts?: {
+	configPath?: string;
+	readFileSync?: (path: string) => string;
+}): GuardrailsConfig {
+	const read =
+		opts?.readFileSync ?? ((p: string) => fs.readFileSync(p, "utf-8"));
+	const configPath = opts?.configPath ?? defaultConfigPath();
+
+	const raw = read(configPath);
+	const parsed = JSON.parse(raw);
+
+	return applyDefaults(parsed as Partial<GuardrailsConfig>);
+}
+
+function applyDefaults(partial: Partial<GuardrailsConfig>): GuardrailsConfig {
+	return {
+		enabled: partial.enabled ?? true,
+		features: {
+			policies: partial.features?.policies ?? true,
+			permissionGate: partial.features?.permissionGate ?? true,
+			pathAccess: partial.features?.pathAccess ?? false,
+		},
+		pathAccess: {
+			mode: partial.pathAccess?.mode ?? "ask",
+			allowedPaths: partial.pathAccess?.allowedPaths ?? [],
+		},
+		policies: {
+			rules: partial.policies?.rules ?? [],
+		},
+		permissionGate: {
+			patterns: partial.permissionGate?.patterns ?? [],
+			customPatterns: partial.permissionGate?.customPatterns ?? [],
+			requireConfirmation: partial.permissionGate?.requireConfirmation ?? true,
+			allowedPatterns: partial.permissionGate?.allowedPatterns ?? [],
+			autoDenyPatterns: partial.permissionGate?.autoDenyPatterns ?? [],
+		},
+	};
+}

--- a/home/.pi/agent/extensions/guardrails/index.ts
+++ b/home/.pi/agent/extensions/guardrails/index.ts
@@ -1,0 +1,252 @@
+import * as path from "node:path";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { isToolCallEventType } from "@earendil-works/pi-coding-agent";
+import { loadConfig } from "./config.js";
+import { matchPath, type MatchResult } from "./policy-matcher.js";
+import { extractPaths } from "./path-extractor.js";
+import { matchCommand } from "./permission-gate-matcher.js";
+import type { GuardrailsConfig } from "./config.js";
+
+let config: GuardrailsConfig | null = null;
+let configError: string | null = null;
+let denialCount = 0;
+let awarenessSent = false;
+
+function buildDenialReason(match: MatchResult, filePath: string) {
+	if (match.protection === "readOnly") {
+		return {
+			block: true,
+			reason: `Access denied: ${filePath} is read-only (guardrails policy: ${match.ruleId})`,
+		} as const;
+	}
+	return {
+		block: true,
+		reason: `Access denied by guardrails policy: ${match.ruleId} — ${match.reason}`,
+	} as const;
+}
+
+function resolvePath(filePath: string, cwd: string): string {
+	return path.isAbsolute(filePath) ? filePath : path.resolve(cwd, filePath);
+}
+
+export default function (pi: ExtensionAPI) {
+	// --- Config loading on session start ---
+
+	pi.on("session_start", async (_event, _ctx) => {
+		try {
+			config = loadConfig();
+			configError = null;
+		} catch (err) {
+			config = null;
+			configError = err instanceof Error ? err.message : String(err);
+			console.warn(`[guardrails] Failed to load config: ${configError}`);
+		}
+		denialCount = 0;
+		awarenessSent = false;
+	});
+
+	// --- Awareness injection on first turn ---
+
+	pi.on("before_agent_start", async (_event, _ctx) => {
+		if (!config || configError) return;
+		if (!config.enabled) return;
+		if (awarenessSent) return;
+
+		const lines: string[] = [];
+		lines.push("Guardrails are active:");
+
+		if (config.features.policies) {
+			const noAccessRules = config.policies.rules.filter(
+				(r) => r.protection === "noAccess",
+			);
+			const readOnlyRules = config.policies.rules.filter(
+				(r) => r.protection === "readOnly",
+			);
+
+			if (noAccessRules.length > 0) {
+				const patterns = noAccessRules.flatMap((r) =>
+					r.patterns.map((p) => p.pattern),
+				);
+				lines.push(`- Secret files (${patterns.join(", ")}) are inaccessible`);
+			}
+			if (readOnlyRules.length > 0) {
+				const patterns = readOnlyRules.flatMap((r) =>
+					r.patterns.map((p) => p.pattern),
+				);
+				lines.push(`- Protected paths (${patterns.join(", ")}) are read-only`);
+			}
+		}
+
+		const allGatePatterns = [
+			...config.permissionGate.patterns,
+			...config.permissionGate.customPatterns,
+		];
+		if (config.features.permissionGate && allGatePatterns.length > 0) {
+			const gatePatterns = allGatePatterns.map((p) => p.pattern);
+			lines.push(
+				`- Dangerous commands (${gatePatterns.join(", ")}) require your confirmation`,
+			);
+		}
+
+		awarenessSent = true;
+
+		return {
+			message: {
+				customType: "guardrails-awareness",
+				content: lines.join("\n"),
+				display: true,
+			},
+		};
+	});
+
+	// --- Tool call interception ---
+
+	pi.on("tool_call", async (event, ctx) => {
+		if (!config || configError) return;
+		if (!config.enabled) return;
+
+		// --- Bash tool: PermissionGate + Policy checks on extracted paths ---
+		if (isToolCallEventType("bash", event)) {
+			const command = event.input.command;
+
+			// PermissionGate checks
+			if (config.features.permissionGate) {
+				const gateMatch = matchCommand(command, config);
+				if (gateMatch) {
+					if (gateMatch.autoDeny) {
+						denialCount++;
+						return {
+							block: true,
+							reason: `Access denied by guardrails: ${gateMatch.description}`,
+						};
+					}
+
+					if (config.permissionGate.requireConfirmation) {
+						const allowed = await ctx.ui.confirm(
+							`Dangerous command detected`,
+							`${gateMatch.description}\n\nCommand: ${command}\n\nAllow?`,
+						);
+						if (!allowed) {
+							denialCount++;
+							return {
+								block: true,
+								reason: "Permission denied by user",
+							};
+						}
+					}
+				}
+			}
+
+			// Policy checks on extracted paths
+			if (config.features.policies) {
+				const extractedPaths = extractPaths(command);
+				for (const filePath of extractedPaths) {
+					const absolutePath = resolvePath(filePath, ctx.cwd);
+
+					const match = matchPath(absolutePath, config, ctx.cwd);
+					if (!match) continue;
+
+					denialCount++;
+					return buildDenialReason(match, filePath);
+				}
+			}
+
+			return; // No blocks
+		}
+
+		// --- File tools: Policy checks ---
+		if (!config.features.policies) return;
+
+		let filePath: string | undefined;
+
+		// Extract path from tool input
+		if (isToolCallEventType("read", event)) {
+			filePath = event.input.path;
+		} else if (isToolCallEventType("write", event)) {
+			filePath = event.input.path;
+		} else if (isToolCallEventType("edit", event)) {
+			filePath = event.input.path;
+		} else if (isToolCallEventType("find", event)) {
+			filePath = event.input.path;
+		} else if (isToolCallEventType("grep", event)) {
+			filePath = event.input.path;
+		}
+
+		if (!filePath) return;
+
+		// Normalize to absolute path
+		const absolutePath = resolvePath(filePath, ctx.cwd);
+
+		// Check against policies
+		const match = matchPath(absolutePath, config, ctx.cwd);
+		if (!match) return;
+
+		denialCount++;
+		return buildDenialReason(match, filePath);
+	});
+
+	// --- /guardrails command ---
+
+	pi.registerCommand("guardrails", {
+		description: "Guardrails extension status and control",
+		handler: async (args, ctx) => {
+			if (!args || args.trim() === "" || args.trim() === "status") {
+				const lines: string[] = [];
+				lines.push("Guardrails Status");
+				lines.push("═════════════════");
+
+				if (configError) {
+					lines.push(`Config: ERROR — ${configError}`);
+				} else if (!config) {
+					lines.push("Config: Not loaded");
+				} else {
+					lines.push(`Config: ~/.pi/agent/guardrails.json (loaded)`);
+					lines.push(`Master: ${config.enabled ? "enabled" : "disabled"}`);
+					lines.push(
+						`Policies: ${config.features.policies ? "enabled" : "disabled"} (${config.policies.rules.length} rules)`,
+					);
+					lines.push(
+						`PermissionGates: ${config.features.permissionGate ? "enabled" : "disabled"} (${config.permissionGate.patterns.length + config.permissionGate.customPatterns.length} patterns)`,
+					);
+					lines.push(
+						`PathAccess: ${config.features.pathAccess ? "enabled" : "disabled"}`,
+					);
+					lines.push(`Denials this session: ${denialCount}`);
+				}
+
+				ctx.ui.notify(lines.join("\n"), "info");
+				return;
+			}
+
+			if (args.trim() === "reload") {
+				try {
+					config = loadConfig();
+					configError = null;
+					denialCount = 0;
+					ctx.ui.notify("Guardrails config reloaded", "info");
+				} catch (err) {
+					config = null;
+					configError = err instanceof Error ? err.message : String(err);
+					ctx.ui.notify(`Reload failed: ${configError}`, "error");
+				}
+				return;
+			}
+
+			if (args.trim() === "help") {
+				ctx.ui.notify(
+					"Guardrails commands:\n" +
+						"  /guardrails        Show status\n" +
+						"  /guardrails reload Re-read config from disk\n" +
+						"  /guardrails help   Show this help",
+					"info",
+				);
+				return;
+			}
+
+			ctx.ui.notify(
+				"Unknown command. Run /guardrails help for available commands.",
+				"warning",
+			);
+		},
+	});
+}

--- a/home/.pi/agent/extensions/guardrails/path-extractor.ts
+++ b/home/.pi/agent/extensions/guardrails/path-extractor.ts
@@ -1,0 +1,22 @@
+/**
+ * Extracts file-like paths from bash command strings.
+ * Matches tokens starting with `/`, `~`, `./`, `../`,
+ * including single- and double-quoted paths.
+ */
+export function extractPaths(command: string): string[] {
+	const paths: string[] = [];
+
+	// Single-pass combined regex — preserves source order
+	// Group 1: double-quoted paths
+	// Group 2: single-quoted paths
+	// Group 3: bare (unquoted) paths
+	const combinedRe =
+		/"([\/][^"]*|~[^"]*|\.[\/][^"]*|\.\.[\/][^"]*)"|'([\/][^']*|~[^']*|\.[\/][^']*|\.\.[\/][^']*)'|([\/][^\s'"]+|~[^\s'"]*|\.[\/][^\s'"]*|\.\.[\/][^\s'"]*)/g;
+
+	let m: RegExpExecArray | null;
+	while ((m = combinedRe.exec(command)) !== null) {
+		paths.push(m[1] ?? m[2] ?? m[3]);
+	}
+
+	return paths;
+}

--- a/home/.pi/agent/extensions/guardrails/permission-gate-matcher.ts
+++ b/home/.pi/agent/extensions/guardrails/permission-gate-matcher.ts
@@ -1,0 +1,45 @@
+import type { GuardrailsConfig } from "./config.js";
+
+export interface GateMatchResult {
+	gate: string;
+	description: string;
+	autoDeny: boolean;
+}
+
+export function matchCommand(
+	command: string,
+	config: GuardrailsConfig,
+): GateMatchResult | null {
+	const gate = config.permissionGate;
+	const allPatterns = [...gate.patterns, ...gate.customPatterns];
+	const trimmed = command.trim().toLowerCase();
+
+	// Check autoDenyPatterns first — these must never be bypassed
+	for (const dp of gate.autoDenyPatterns) {
+		if (trimmed.includes(dp.pattern.toLowerCase())) {
+			return { gate: dp.pattern, description: dp.description, autoDeny: true };
+		}
+	}
+
+	// Check gate patterns — require confirmation
+	for (const p of allPatterns) {
+		if (trimmed.includes(p.pattern.toLowerCase())) {
+			// AllowedPatterns exempt the entire command only if it exactly matches
+			// (prevents compound commands like "git status && rm -rf /" from bypassing)
+			if (
+				gate.allowedPatterns.some(
+					(ap) => trimmed === ap.pattern.toLowerCase().trim(),
+				)
+			) {
+				return null;
+			}
+			return {
+				gate: p.pattern,
+				description: p.description,
+				autoDeny: false,
+			};
+		}
+	}
+
+	return null;
+}

--- a/home/.pi/agent/extensions/guardrails/policy-matcher.ts
+++ b/home/.pi/agent/extensions/guardrails/policy-matcher.ts
@@ -1,0 +1,181 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { GuardrailsConfig, PolicyRule } from "./config.js";
+
+export interface MatchResult {
+	ruleId: string;
+	protection: "noAccess" | "readOnly";
+	reason: string;
+}
+
+export interface MatchPathOptions {
+	existsSync?: (p: string) => boolean;
+}
+
+/** Check if a path is in the global allowedPaths whitelist.
+ * Unlike policy patterns, allowedPaths use exact matching for non-glob paths
+ * to avoid accidentally whitelisting directory contents when a file is intended.
+ */
+function isPathAllowed(
+	absolutePath: string,
+	config: GuardrailsConfig,
+	cwd: string,
+): boolean {
+	return config.pathAccess.allowedPaths.some((ap) =>
+		allowedPathMatches(ap.pattern, absolutePath, cwd),
+	);
+}
+
+/** Match an allowedPath pattern against an absolute path.
+ * Uses exact matching for non-glob patterns (no accidental directory prefix expansion).
+ */
+function allowedPathMatches(
+	pattern: string,
+	absolutePath: string,
+	cwd: string,
+): boolean {
+	// Expand ~ to homedir
+	let expanded = pattern;
+	if (pattern.startsWith("~")) {
+		const rest = pattern.slice(1);
+		const remainder = rest.startsWith(path.sep) ? rest.slice(1) : rest;
+		expanded = path.join(os.homedir(), remainder);
+	} else if (!path.isAbsolute(pattern)) {
+		expanded = path.resolve(cwd, pattern);
+	}
+
+	// Directory prefix patterns (ending with /**)
+	if (expanded.endsWith(`${path.sep}**`) || expanded.endsWith("/**")) {
+		const dir = expanded.replace(/[\\/]\*\*$/, "");
+		return absolutePath === dir || absolutePath.startsWith(dir + path.sep);
+	}
+
+	// Patterns with glob chars — glob match against full path
+	if (expanded.includes("*") || expanded.includes("?")) {
+		return globMatch(expanded, absolutePath);
+	}
+
+	// No glob chars, no /** — exact match only
+	return absolutePath === expanded;
+}
+
+export function matchPath(
+	absolutePath: string,
+	config: GuardrailsConfig,
+	cwd: string,
+	opts?: MatchPathOptions,
+): MatchResult | null {
+	// Check allowedPaths global whitelist first
+	if (isPathAllowed(absolutePath, config, cwd)) {
+		return null;
+	}
+
+	for (const rule of config.policies.rules) {
+		if (ruleMatchesPath(rule, absolutePath, cwd, opts)) {
+			return {
+				ruleId: rule.id,
+				protection: rule.protection,
+				reason: rule.description,
+			};
+		}
+	}
+	return null;
+}
+
+function ruleMatchesPath(
+	rule: PolicyRule,
+	absolutePath: string,
+	cwd: string,
+	opts?: MatchPathOptions,
+): boolean {
+	const exists = opts?.existsSync ?? fs.existsSync;
+
+	// onlyIfExists check
+	if (rule.onlyIfExists && !exists(absolutePath)) {
+		return false;
+	}
+
+	for (const pat of rule.patterns) {
+		if (patternMatchesPath(pat.pattern, absolutePath, cwd)) {
+			// Check allowedPatterns exemption
+			if (
+				rule.allowedPatterns?.some((ap) =>
+					patternMatchesPath(ap.pattern, absolutePath, cwd),
+				)
+			) {
+				continue;
+			}
+			return true;
+		}
+	}
+	return false;
+}
+
+function patternMatchesPath(
+	pattern: string,
+	absolutePath: string,
+	cwd: string,
+): boolean {
+	// Track original pattern characteristics before resolution
+	const isSimpleName =
+		!pattern.includes("*") &&
+		!pattern.includes("?") &&
+		!pattern.includes("/") &&
+		!pattern.startsWith("~");
+	// Filename pattern: no separators in original (glob chars OK)
+	const isFilenamePattern =
+		!pattern.includes("/") &&
+		!pattern.startsWith("~") &&
+		!pattern.includes("\\");
+
+	// Expand ~ to homedir
+	let expanded = pattern;
+	if (pattern.startsWith("~")) {
+		const rest = pattern.slice(1);
+		// Handle ~/ prefix (not just ~)
+		const remainder = rest.startsWith(path.sep) ? rest.slice(1) : rest;
+		expanded = path.join(os.homedir(), remainder);
+	} else if (!path.isAbsolute(pattern)) {
+		// Resolve relative to cwd
+		expanded = path.resolve(cwd, pattern);
+	}
+
+	// Simple name (no glob chars, no separator in original) — match any path component
+	if (isSimpleName) {
+		const components = absolutePath.split(path.sep);
+		return components.includes(pattern);
+	}
+
+	// Filename pattern (no path separator in original) — match against basename only
+	if (isFilenamePattern) {
+		const basename = path.basename(absolutePath);
+		return globMatch(pattern, basename);
+	}
+
+	// Directory prefix patterns (ending with /**)
+	if (expanded.endsWith(`${path.sep}**`) || expanded.endsWith("/**")) {
+		const dir = expanded.replace(/[\\/]\*\*$/, "");
+		return absolutePath === dir || absolutePath.startsWith(dir + path.sep);
+	}
+
+	// Full path pattern with no glob chars — treat as directory prefix (match dir and contents)
+	if (!expanded.includes("*") && !expanded.includes("?")) {
+		return (
+			absolutePath === expanded || absolutePath.startsWith(expanded + path.sep)
+		);
+	}
+
+	// Full path pattern with glob chars — match against full path
+	return globMatch(expanded, absolutePath);
+}
+
+function globMatch(pattern: string, text: string): boolean {
+	// Convert glob pattern to regex
+	const regex = pattern
+		.replace(/[.+?^${}()|[\]\\]/g, "\\$&")
+		.replace(/\*\*/g, "(.*)")
+		.replace(/\*/g, "([^/]*)")
+		.replace(/\?/g, "([^/])");
+	return new RegExp(`^${regex}$`).test(text);
+}

--- a/home/.pi/agent/guardrails.json
+++ b/home/.pi/agent/guardrails.json
@@ -1,11 +1,5 @@
 {
 	"enabled": true,
-	"version": "0.9.0-20260327",
-	"onboarding": {
-		"completed": true,
-		"completedAt": "2026-05-16T14:33:48.971Z",
-		"version": "0.9.0-20260327"
-	},
 	"features": {
 		"policies": true,
 		"permissionGate": true,
@@ -212,10 +206,6 @@
 		"customPatterns": [],
 		"requireConfirmation": true,
 		"allowedPatterns": [],
-		"autoDenyPatterns": [],
-		"explainCommands": false,
-		"explainModel": null,
-		"explainTimeout": 5000
-	},
-	"applyBuiltinDefaults": true
+		"autoDenyPatterns": []
+	}
 }

--- a/home/.pi/agent/settings.json
+++ b/home/.pi/agent/settings.json
@@ -1,29 +1,30 @@
 {
-	"lastChangelogVersion": "0.75.1",
-	"packages": [
-		"npm:@aliou/pi-guardrails",
-		"npm:pi-autoresearch",
-		"npm:pi-bash-live-view",
-		"npm:pi-interview",
-		"npm:pi-lens",
-		"npm:pi-markdown-preview",
-		"npm:pi-mcp-adapter",
-		"npm:pi-powerline-footer",
-		"npm:pi-review-loop",
-		"npm:pi-rewind",
-		"npm:pi-slop-review",
-		"npm:pi-smart-fetch"
-	],
-	"extensions": ["~/dotfiles/home/.pi/agent/extensions"],
-	"defaultProvider": "github-copilot",
-	"defaultModel": "claude-opus-4.6",
-	"defaultThinkingLevel": "high",
-	"treeFilterMode": "no-tools",
-	"theme": "dark",
-	"reviewerLoop": {
-		"maxIterations": 3,
-		"autoTrigger": true,
-		"freshContext": true,
-		"reviewPrompt": "template:double-check"
-	}
+  "lastChangelogVersion": "0.75.4",
+  "packages": [
+    "npm:pi-autoresearch",
+    "npm:pi-bash-live-view",
+    "npm:pi-interview",
+    "npm:pi-lens",
+    "npm:pi-markdown-preview",
+    "npm:pi-mcp-adapter",
+    "npm:pi-powerline-footer",
+    "npm:pi-review-loop",
+    "npm:pi-rewind",
+    "npm:pi-slop-review",
+    "npm:pi-smart-fetch"
+  ],
+  "extensions": [
+    "~/dotfiles/home/.pi/agent/extensions"
+  ],
+  "defaultProvider": "github-copilot",
+  "defaultModel": "claude-opus-4.6",
+  "defaultThinkingLevel": "high",
+  "treeFilterMode": "no-tools",
+  "theme": "dark",
+  "reviewerLoop": {
+    "maxIterations": 3,
+    "autoTrigger": true,
+    "freshContext": true,
+    "reviewPrompt": "template:double-check"
+  }
 }


### PR DESCRIPTION
Disable the quick terminal autohide feature in the Ghostty configuration. Introduce the Guardrails extension with configurations for policy and permission gates to enhance command handling and automation capabilities.