### PR TITLE
fix: update plugin aliases and improve update command in settings

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -162,8 +162,9 @@
 		"command": "bash /Users/xavier.riu/dotfiles/home/.claude/statusline.sh"
 	},
 	"enabledPlugins": {
-		"slop-review@slop-review": true,
-		"ralph-wiggum@claude-code-plugins": true
+		"agent-sdk-dev@claude-code-plugins": true,
+		"ralph-wiggum@claude-code-plugins": true,
+		"slop-review@slop-review": true
 	},
 	"extraKnownMarketplaces": {
 		"slop-review": {

--- a/home/.config/fish/conf.d/aliases.fish
+++ b/home/.config/fish/conf.d/aliases.fish
@@ -71,7 +71,7 @@ alias zed="/Applications/Zed.app/Contents/MacOS/cli"
 alias oc="OPENCODE_EXPERIMENTAL_LSP_TOOL=1 OPENCODE_ENABLE_EXA=1 OPENCODE_EXPERIMENTAL_PLAN_MODE=1 opencode"
 
 # Update
-alias update="brew-update; pi update; claude update; rustup-update; npm-update; bun-update"
+alias update="brew-update; pi update; brew upgrade claude-code; rustup-update; npm-update; bun-update"
 
 # LM internal alias
 functions -e lm 2>/dev/null

--- a/home/.pi/agent/settings.json
+++ b/home/.pi/agent/settings.json
@@ -1,5 +1,5 @@
 {
-	"lastChangelogVersion": "0.78.0",
+	"lastChangelogVersion": "0.78.1",
 	"packages": [
 		"npm:pi-bash-live-view",
 		"npm:pi-interview",
@@ -14,8 +14,8 @@
 		"npm:pi-design-deck"
 	],
 	"extensions": ["~/dotfiles/home/.pi/agent/extensions"],
-	"defaultProvider": "alibaba",
-	"defaultModel": "qwen3.6-plus",
+	"defaultProvider": "github-copilot",
+	"defaultModel": "claude-opus-4.6",
 	"defaultThinkingLevel": "high",
 	"treeFilterMode": "no-tools",
 	"theme": "dark",


### PR DESCRIPTION
This pull request includes several configuration updates to improve plugin management, update default AI provider settings, and refine update processes. The most significant changes are grouped below:

Configuration and Plugin Management:

* Reordered and added the `agent-sdk-dev@claude-code-plugins` plugin to the `enabledPlugins` list in `settings.json`, ensuring it is now enabled alongside existing plugins.

Update Processes:

* Modified the `update` alias in `aliases.fish` to use `brew upgrade claude-code` instead of `claude update`, streamlining the update process for the `claude-code` package.

AI Provider and Model Defaults:

* Changed the default AI provider from `alibaba` to `github-copilot` and the default model from `qwen3.6-plus` to `claude-opus-4.6` in the PI agent settings, reflecting a shift in preferred AI backend.

Version Tracking:

* Updated the `lastChangelogVersion` in the PI agent settings from `0.78.0` to `0.78.1` to track the latest changes.