### PR TITLE
Refactor Zed settings to use Gemma4 model

### DIFF
--- a/home/.config/zed/settings.json
+++ b/home/.config/zed/settings.json
@@ -4,8 +4,8 @@
     "commit_message_instructions": "Use the Conventional Commits format: <type>(<scope>): <description>.",
     "commit_message_model": {
       "enable_thinking": false,
-      "model": "go/deepseek-v4-flash",
-      "provider": "opencode",
+      "model": "gemma4:e2b",
+      "provider": "ollama",
     },
     "default_model": {
       "effort": "xhigh",


### PR DESCRIPTION
This pull request updates the configuration for the commit message generation model in `settings.json`. The main change is switching the model and provider used for generating commit messages.

- **Commit Message Model Update:**
  - Changed the `commit_message_model` from using the `"go/deepseek-v4-flash"` model with the `"opencode"` provider to the `"gemma4:e2b"` model with the `"ollama"` provider.