### PR TITLE
claude configured for provider: opencode/alibaba

### DIFF
--- a/home/.claude/config/alibaba.json
+++ b/home/.claude/config/alibaba.json
@@ -1,0 +1,159 @@
+{
+    "$schema": "https://json.schemastore.org/claude-code-settings.json",
+    "cleanupPeriodDays": 365,
+    "env": {
+        "ANTHROPIC_DEFAULT_HAIKU_MODEL": "qwen3.7-plus",
+        "ANTHROPIC_DEFAULT_OPUS_MODEL": "qwen3.7-plus",
+        "ANTHROPIC_DEFAULT_SONNET_MODEL": "qwen3.7-plus",
+        "ANTHROPIC_MODEL": "qwen3.7-plus",
+        "CLAUDE_CODE_DISABLE_1M_CONTEXT": "0",
+        "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1",
+        "CLAUDE_CODE_DISABLE_AUTO_MEMORY": "0",
+        "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
+        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+        "CLAUDE_CODE_ENABLE_AWAY_SUMMARY": "0",
+        "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION": "true",
+        "CLAUDE_CODE_ENABLE_TELEMETRY": "0",
+        "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+        "CLAUDE_CODE_NO_FLICKER": "1",
+        "CLAUDE_CODE_SUBAGENT_MODEL": "qwen3.7-plus",
+        "DISABLE_ERROR_REPORTING": "1",
+        "DISABLE_TELEMETRY": "1"
+    },
+    "attribution": {
+        "commit": "",
+        "pr": ""
+    },
+    "permissions": {
+        "allow": [],
+        "deny": [
+            "Bash(dd *)",
+            "Bash(diskutil *)",
+            "Bash(mkfs *)",
+            "Bash(rm -rf /*)",
+            "Bash(rm -rf /)",
+            "Bash(rm -rf ~*)",
+            "Bash(rm -rf $HOME*)",
+            "Bash(rm -rf .*)",
+            "Bash(sudo rm -rf *)",
+            "Bash(git push *)",
+            "Bash(git reset --hard *)",
+            "Bash(npm publish *)",
+            "Bash(terraform apply *)",
+            "Bash(terraform destroy *)",
+            "Read(./.env*)",
+            "Read(./config/credentials.json)",
+            "Read(./secrets/**)",
+            "Read(~/.aws/**)",
+            "Read(~/.ssh/**)"
+        ],
+        "ask": [],
+        "defaultMode": "bypassPermissions",
+        "additionalDirectories": ["~/.claude/"]
+    },
+    "model": "qwen3.7-plus",
+    "statusLine": {
+        "type": "command",
+        "command": "bash /Users/xavier.riu/dotfiles/home/.claude/status-line.sh"
+    },
+    "enabledPlugins": {
+        "agent-sdk-dev@claude-code-plugins": true,
+        "frontend-design@claude-plugins-official": true,
+        "plannotator@plannotator": true,
+        "plugin-dev@claude-code-plugins": true,
+        "slop-review@slop-review": true,
+        "typescript-lsp@claude-plugins-official": true,
+        "rust-analyzer-lsp@claude-plugins-official": true,
+        "visual-explainer@visual-explainer-marketplace": true
+    },
+    "extraKnownMarketplaces": {
+        "slop-review": {
+            "source": {
+                "source": "github",
+                "repo": "dbachelder/slop-review"
+            }
+        },
+        "claude-code-plugins": {
+            "source": {
+                "source": "github",
+                "repo": "anthropics/claude-code"
+            }
+        },
+        "supergoal": {
+            "source": {
+                "source": "git",
+                "url": "https://github.com/robzilla1738/supergoal.git"
+            }
+        },
+        "plannotator": {
+            "source": {
+                "source": "github",
+                "repo": "backnotprop/plannotator"
+            }
+        },
+        "visual-explainer-marketplace": {
+            "source": {
+                "source": "github",
+                "repo": "nicobailon/visual-explainer"
+            }
+        }
+    },
+    "alwaysThinkingEnabled": true,
+    "effortLevel": "high",
+    "autoCompactWindow": 180000,
+    "fastMode": false,
+    "skipDangerousModePermissionPrompt": true,
+    "theme": "dark",
+    "hooks": {
+        "PreToolUse": [
+            {
+                "matcher": "Grep|Glob",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "~/.claude/hooks/cbm-code-discovery-gate",
+                        "timeout": 5
+                    }
+                ]
+            }
+        ],
+        "SessionStart": [
+            {
+                "matcher": "startup",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "~/.claude/hooks/cbm-session-reminder"
+                    }
+                ]
+            },
+            {
+                "matcher": "resume",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "~/.claude/hooks/cbm-session-reminder"
+                    }
+                ]
+            },
+            {
+                "matcher": "clear",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "~/.claude/hooks/cbm-session-reminder"
+                    }
+                ]
+            },
+            {
+                "matcher": "compact",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "~/.claude/hooks/cbm-session-reminder"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/home/.claude/config/opencode.json
+++ b/home/.claude/config/opencode.json
@@ -1,0 +1,159 @@
+{
+    "$schema": "https://json.schemastore.org/claude-code-settings.json",
+    "cleanupPeriodDays": 365,
+    "env": {
+        "ANTHROPIC_DEFAULT_HAIKU_MODEL": "minimax-m3",
+        "ANTHROPIC_DEFAULT_OPUS_MODEL": "minimax-m3",
+        "ANTHROPIC_DEFAULT_SONNET_MODEL": "minimax-m3",
+        "ANTHROPIC_MODEL": "minimax-m3",
+        "CLAUDE_CODE_DISABLE_1M_CONTEXT": "0",
+        "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1",
+        "CLAUDE_CODE_DISABLE_AUTO_MEMORY": "0",
+        "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
+        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+        "CLAUDE_CODE_ENABLE_AWAY_SUMMARY": "0",
+        "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION": "true",
+        "CLAUDE_CODE_ENABLE_TELEMETRY": "0",
+        "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+        "CLAUDE_CODE_NO_FLICKER": "1",
+        "CLAUDE_CODE_SUBAGENT_MODEL": "minimax-m3",
+        "DISABLE_ERROR_REPORTING": "1",
+        "DISABLE_TELEMETRY": "1"
+    },
+    "attribution": {
+        "commit": "",
+        "pr": ""
+    },
+    "permissions": {
+        "allow": [],
+        "deny": [
+            "Bash(dd *)",
+            "Bash(diskutil *)",
+            "Bash(mkfs *)",
+            "Bash(rm -rf /*)",
+            "Bash(rm -rf /)",
+            "Bash(rm -rf ~*)",
+            "Bash(rm -rf $HOME*)",
+            "Bash(rm -rf .*)",
+            "Bash(sudo rm -rf *)",
+            "Bash(git push *)",
+            "Bash(git reset --hard *)",
+            "Bash(npm publish *)",
+            "Bash(terraform apply *)",
+            "Bash(terraform destroy *)",
+            "Read(./.env*)",
+            "Read(./config/credentials.json)",
+            "Read(./secrets/**)",
+            "Read(~/.aws/**)",
+            "Read(~/.ssh/**)"
+        ],
+        "ask": [],
+        "defaultMode": "bypassPermissions",
+        "additionalDirectories": ["~/.claude/"]
+    },
+    "model": "minimax-m3",
+    "statusLine": {
+        "type": "command",
+        "command": "bash /Users/xavier.riu/dotfiles/home/.claude/status-line.sh"
+    },
+    "enabledPlugins": {
+        "agent-sdk-dev@claude-code-plugins": true,
+        "frontend-design@claude-plugins-official": true,
+        "plannotator@plannotator": true,
+        "plugin-dev@claude-code-plugins": true,
+        "slop-review@slop-review": true,
+        "typescript-lsp@claude-plugins-official": true,
+        "rust-analyzer-lsp@claude-plugins-official": true,
+        "visual-explainer@visual-explainer-marketplace": true
+    },
+    "extraKnownMarketplaces": {
+        "slop-review": {
+            "source": {
+                "source": "github",
+                "repo": "dbachelder/slop-review"
+            }
+        },
+        "claude-code-plugins": {
+            "source": {
+                "source": "github",
+                "repo": "anthropics/claude-code"
+            }
+        },
+        "supergoal": {
+            "source": {
+                "source": "git",
+                "url": "https://github.com/robzilla1738/supergoal.git"
+            }
+        },
+        "plannotator": {
+            "source": {
+                "source": "github",
+                "repo": "backnotprop/plannotator"
+            }
+        },
+        "visual-explainer-marketplace": {
+            "source": {
+                "source": "github",
+                "repo": "nicobailon/visual-explainer"
+            }
+        }
+    },
+    "alwaysThinkingEnabled": true,
+    "effortLevel": "high",
+    "autoCompactWindow": 180000,
+    "fastMode": false,
+    "skipDangerousModePermissionPrompt": true,
+    "theme": "dark",
+    "hooks": {
+        "PreToolUse": [
+            {
+                "matcher": "Grep|Glob",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "~/.claude/hooks/cbm-code-discovery-gate",
+                        "timeout": 5
+                    }
+                ]
+            }
+        ],
+        "SessionStart": [
+            {
+                "matcher": "startup",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "~/.claude/hooks/cbm-session-reminder"
+                    }
+                ]
+            },
+            {
+                "matcher": "resume",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "~/.claude/hooks/cbm-session-reminder"
+                    }
+                ]
+            },
+            {
+                "matcher": "clear",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "~/.claude/hooks/cbm-session-reminder"
+                    }
+                ]
+            },
+            {
+                "matcher": "compact",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "~/.claude/hooks/cbm-session-reminder"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/home/.config/fish/conf.d/claude.fish
+++ b/home/.config/fish/conf.d/claude.fish
@@ -41,12 +41,26 @@ function _configure_claude_provider
     set -gx DISABLE_ERROR_REPORTING 1
     set -gx DISABLE_TELEMETRY 1
 
-    # Execute claude with any remaining arguments (skip first 4)
+    # Load provider-specific config if available
+    set -l config_file "$HOME/dotfiles/home/.claude/config/$provider.json"
+    set -l claude_args
+    if test -f "$config_file"
+        set -a claude_args --settings "$config_file"
+    end
+
+    # Append any remaining passthrough arguments (skip first 4)
     if set -q argv[5]
-        claude $argv[5..-1]
+        set -a claude_args $argv[5..-1]
+    end
+
+    if set -q claude_args[1]
+        claude $claude_args
     else
         echo "Claude configured for provider: $provider"
         echo "Model: $model"
+        if test -f "$config_file"
+            echo "Config: $config_file"
+        end
         echo "Run 'claude' to start the interactive session"
     end
 end
@@ -65,7 +79,7 @@ function opencode
     set -l provider "opencode"
     set -l url "https://opencode.ai/zen/go/v1/messages"
     set -l apiKey $OPENCODE_API_KEY
-    set -l model "opencode-go/minimax-m3"
+    set -l model "minimax-m3"
     _configure_claude_provider $provider $apiKey $model $url $argv
 end
 


### PR DESCRIPTION
This pull request introduces provider-specific configuration support for Claude by loading JSON config files based on the selected provider. It also adds new configuration files for the `alibaba` and `opencode` providers, and standardizes the model name for the `opencode` provider.

The most important changes include:

**Provider-specific configuration loading:**

* The `_configure_claude_provider` function now checks for a provider-specific config file (e.g., `~/.claude/config/opencode.json`) and passes it to Claude using the `--settings` flag if present. This allows for easier management of provider-specific settings.

**New and updated config files:**

* Added `alibaba.json` and `opencode.json` configuration files under `home/.claude/config/`, each specifying environment variables, permissions, plugins, and other settings tailored for their respective providers. [[1]](diffhunk://#diff-ee573755b8970d4ab9fac394b0e75c3f51a6848647a40109c1fcaa42f454ac5fR1-R159) [[2]](diffhunk://#diff-56fe67264ed3dad6baca4dab81d0b1115052733569caf7873fdc85d85657bab6R1-R159)

**Model name standardization:**

* The `opencode` function now uses the model name `minimax-m3` (instead of `opencode-go/minimax-m3`) to match the value expected in the new config file.