### PR TITLE
chore(mcp): Update mcp-server URLs to include AWS_REGION=us-east-1

### DIFF
--- a/home/.claude/.mcp.json
+++ b/home/.claude/.mcp.json
@@ -1,14 +1,5 @@
 {
     "mcpServers": {
-        "aws-mcp": {
-            "command": "uvx",
-            "args": [
-                "mcp-proxy-for-aws==1.6.1",
-                "https://aws-mcp.us-east-1.api.aws/mcp",
-                "--metadata",
-                "AWS_REGION=us-east-1"
-            ]
-        },
         "executor": {
             "type": "http",
             "url": "http://localhost:4789/mcp?elicitation_mode=native",


### PR DESCRIPTION
This pull request makes a small change to the `.mcp.json` configuration file, removing the configuration for the `aws-mcp` server. Only the `executor` server configuration remains.